### PR TITLE
Align directory structure and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,23 +42,13 @@ If your virus scanner intervenes when you try to run the executables that come o
 
 ### Plain MASM32
 
-The applications can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
+The current code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
 
-- Current code in the Lasse directory:
-  
-  ```shell
-  ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
-  ```
+```shell
+ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
+```
 
-  The executable will be named LittleWindows.exe.
-
-- Original code in the TinyOriginal directory:
-
-  ```shell
-  ml /coff /I c:\masm32\include Tiny.asm /link /libpath:c:\masm32\lib /subsystem:windows
-  ```
-
-  The executable will be named Tiny.exe.
+The executable will be named LittleWindows.exe.
 
 ### MASM32 with Crinkler
 
@@ -81,7 +71,7 @@ After installing it, the build instructions for both applications are:
 
   ```shell
   ml /c /coff /IC:\masm32\include Tiny.asm 
-  crinkler.exe /NODEFAULTLIB /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:1000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj
+  crinkler.exe /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:2000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj /OUT:tiny.exe
   ```
 
   The executable will be named out.exe.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ After installing it, the build instructions for both applications are:
 
 Current smallest known working executable sizes as of 01/10/2023 are as follows:
 
-| Program | Plain MASM32 | With Crinkler |
-|-|-:|-:|
-| `Lasse\LittleWindows.asm` | 1104 | 824 |
-| `TinyOriginal\Tiny.asm` | 3584 | 644 |
+| Program | Linker | Size in bytes |
+|-|-|-:|
+| `Lasse\LittleWindows.asm` | MASM32 | 1104 |
+| `Lasse\LittleWindows.asm` | Crinkler | 824 |
+| `TinyOriginal\Tiny.asm` | Crinkler | 610 |

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,3 +1,6 @@
 # Directory contents
 
-This directory contains template files that are used to generate actual project deliverables. At the moment, the only template is the one for the repository's [main README.md](../README.md).
+This directory contains templates for the contents of this project. At the moment, it contains two subdirectories:
+
+- [application](application) contains the C application that was the starting point for the original Dave's Garage episode.
+- [readme](readme) contains the template for this repository's [main README.md](../README.md). It is used by at least one of the scripts in the [tools](../tools) directory.

--- a/templates/readme/README.md.template
+++ b/templates/readme/README.md.template
@@ -42,23 +42,13 @@ If your virus scanner intervenes when you try to run the executables that come o
 
 ### Plain MASM32
 
-The applications can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
+The current code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
 
-- Current code in the Lasse directory:
-  
-  ```shell
-  ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
-  ```
+```shell
+ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
+```
 
-  The executable will be named LittleWindows.exe.
-
-- Original code in the TinyOriginal directory:
-
-  ```shell
-  ml /coff /I c:\masm32\include Tiny.asm /link /libpath:c:\masm32\lib /subsystem:windows
-  ```
-
-  The executable will be named Tiny.exe.
+The executable will be named LittleWindows.exe.
 
 ### MASM32 with Crinkler
 
@@ -81,7 +71,7 @@ After installing it, the build instructions for both applications are:
 
   ```shell
   ml /c /coff /IC:\masm32\include Tiny.asm 
-  crinkler.exe /NODEFAULTLIB /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:1000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj
+  crinkler.exe /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:2000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj /OUT:tiny.exe
   ```
 
   The executable will be named out.exe.

--- a/templates/readme/README.md.template
+++ b/templates/readme/README.md.template
@@ -90,7 +90,8 @@ After installing it, the build instructions for both applications are:
 
 Current smallest known working executable sizes as of <!--size-date--> are as follows:
 
-| Program | Plain MASM32 | With Crinkler |
-|-|-:|-:|
-| `Lasse\LittleWindows.asm` | <!--size-little-masm--> | <!--size-little-crinkler--> |
-| `TinyOriginal\Tiny.asm` | <!--size-tiny-masm--> | <!--size-tiny-crinkler--> |
+| Program | Linker | Size in bytes |
+|-|-|-:|
+| `Lasse\LittleWindows.asm` | MASM32 | <!--size-little-masm--> |
+| `Lasse\LittleWindows.asm` | Crinkler | <!--size-little-crinkler--> |
+| `TinyOriginal\Tiny.asm` | Crinkler | <!--size-tiny-crinkler--> |

--- a/tools/build-all.ps1
+++ b/tools/build-all.ps1
@@ -10,7 +10,7 @@ c:\masm32\bin\ml /c /coff LittleWindows.asm
 
 # Build TinyOriginal executables
 Set-Location ..\TinyOriginal
-c:\masm32\bin\ml /coff /I c:\masm32\include Tiny.asm /link /libpath:c:\masm32\lib /subsystem:windows
-..\Crinkler\crinkler.exe /NODEFAULTLIB /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:1000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj
+c:\masm32\bin\ml /c /coff /IC:\masm32\include Tiny.asm
+..\Crinkler\crinkler.exe /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:2000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj /OUT:tiny.exe
 
 Set-Location ..

--- a/tools/build-check.ps1
+++ b/tools/build-check.ps1
@@ -37,8 +37,7 @@ Remove-Item .\Lasse\*.obj,.\Lasse\*.exe,.\TinyOriginal\*.obj,.\TinyOriginal\*.ex
 # Test and check each executable
 $success = RunExecutable ".\Lasse\LittleWindows.exe" 
 $success = (RunExecutable ".\Lasse\out.exe") -and $success
-$success = (RunExecutable ".\TinyOriginal\Tiny.exe") -and $success
-$success = (RunExecutable ".\TinyOriginal\out.exe") -and $success
+$success = (RunExecutable ".\TinyOriginal\tiny.exe") -and $success
 
 Write-Host ""
 

--- a/tools/update-readme-sizes.ps1
+++ b/tools/update-readme-sizes.ps1
@@ -2,7 +2,7 @@
 # Run this script from the repository root, as in: .\tools\update-readme-sizes.ps1
 
 # Get the file contents
-$fileContent = Get-Content -Path '.\templates\README.md.template'
+$fileContent = Get-Content -Path '.\templates\readme\README.md.template'
 
 # Insert current date
 $fileContent = $fileContent -replace '<!--size-date-->', (Get-Date).ToString('MM/dd/yyyy') 
@@ -12,7 +12,6 @@ $fileContent = $fileContent -replace '<!--size-little-masm-->', (Get-Item .\Lass
 $fileContent = $fileContent -replace '<!--size-little-crinkler-->', (Get-Item .\Lasse\out.exe).Length
 
 # Insert file sizes for TinyOriginal executables 
-$fileContent = $fileContent -replace '<!--size-tiny-masm-->', (Get-Item .\TinyOriginal\Tiny.exe).Length
-$fileContent = $fileContent -replace '<!--size-tiny-crinkler-->', (Get-Item .\TinyOriginal\out.exe).Length
+$fileContent = $fileContent -replace '<!--size-tiny-crinkler-->', (Get-Item .\TinyOriginal\tiny.exe).Length
 
 Set-Content -Value $fileContent -Path '.\README.md'


### PR DESCRIPTION
This updates the `templates` directory structure to accomodate the addition of the `templates\application` directory.

It also updates the scripts in `tools` (and the README template) to no longer build a MASM32-linked version of the TinyOriginal application.