### PR TITLE
396 bytes by writing a PE header with hash importer and Crinkler tricks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ And the follow-up episode ["C vs ASM: Making the World's SMALLEST Windows App"](
 
 Code in the repository:
 
-- Current code is in the folder "Lasse"
-- Original code in the folder "TinyOriginal"
+- Optimized version of the original code in the folder "TinyOriginal"
+- Version applying shell coding tactics is in the folder "Lasse"
+- Version using a manually written PE header is in the folder "Theron"
 - QRCode is dead code, was the exe embedded into a QRCode, kept just for posterity
 
 The goal of this project is to make the smallest possible application, without compression, that has the following features:
@@ -42,7 +43,7 @@ If your virus scanner intervenes when you try to run the executables that come o
 
 ### Plain MASM32
 
-The current code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
+The code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
 
 ```shell
 ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
@@ -56,9 +57,9 @@ Crinkler is a compressing linker for Windows, specifically targeted towards exec
 
 Crinkler requires the Windows SDK to be installed. Best (i.e. smallest) results have been achieved with version 10.0.20348.0 of the Windows 10 SDK. It, and other versions can be downloaded from the [Windows SDK archive page](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) on the Microsoft website.
 
-After installing it, the build instructions for both applications are:
+After installing it, the build instructions for the applications that can be built using it are:
 
-- Current code in the Lasse directory:
+- Code in the Lasse directory:
 
   ```shell
   ml /c /coff LittleWindows.asm
@@ -67,7 +68,7 @@ After installing it, the build instructions for both applications are:
 
   The executable will be named out.exe.
 
-- Original code in the TinyOriginal directory:
+- Code in the TinyOriginal directory:
 
   ```shell
   ml /c /coff /IC:\masm32\include Tiny.asm 
@@ -76,12 +77,23 @@ After installing it, the build instructions for both applications are:
 
   The executable will be named tiny.exe.
 
+### Yasm
+
+The code in the Theron directory has to be built with Yasm, which is a rewrite of the NASM assembler under the "new" BSD license. It can be acquired from the [Yasm project download page](https://yasm.tortall.net/Download.html); choose the version "for general use". The assembler is assumed to be renamed to `yasm.exe`. Build instructions using it are:
+
+```shell
+yasm -fbin -o HelloWindows.exe HelloWindows.asm
+```
+
+The executable will be named HelloWindows.exe.
+
 ## Current sizes
 
-Current smallest known working executable sizes as of 01/11/2023 are as follows:
+Current smallest known working executable sizes as of 01/29/2023 are as follows:
 
 | Program | Linker | Size in bytes |
 |-|-|-:|
 | `Lasse\LittleWindows.asm` | MASM32 | 1104 |
 | `Lasse\LittleWindows.asm` | Crinkler | 818 |
+| `Theron\HelloWindows.asm` | Yasm | 396 |
 | `TinyOriginal\Tiny.asm` | Crinkler | 596 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ And the follow-up episode ["C vs ASM: Making the World's SMALLEST Windows App"](
 
 Code in the repository:
 
-- Optimized version of the original code in the folder "TinyOriginal"
+- Optimized version of the original code is in the folder "TinyOriginal"
 - Version applying shell coding tactics is in the folder "Lasse"
 - Version using a manually written PE header is in the folder "Theron"
 - QRCode is dead code, was the exe embedded into a QRCode, kept just for posterity

--- a/Theron/HelloWindows.asm
+++ b/Theron/HelloWindows.asm
@@ -1,0 +1,223 @@
+;-----------------------
+; HelloWindows.asm
+; "Dave's Tiny App" rewritten for maximal utilization of PE header format,
+;   https://github.com/PlummersSoftwareLLC/HelloAssembly
+;
+; Assemble with yasm, https://yasm.tortall.net/
+;   yasm -fbin -o HelloWindows.exe HelloWindows.asm
+;   yasm -fbin -o HelloCompat.exe HelloWindows.asm -DWINECOMPAT
+;
+; 2023-01-27  Theron Tarigo   396 bytes with header_tiny v2023-01-27
+;
+;-----------------------
+
+%include "header_tiny.asm"
+
+    ; header loader leaves eax = 0
+
+    ; We don't need our own window class, we can just use STATIC
+    ; and override the window's properties and wndproc.
+
+%ifdef WINECOMPAT
+    ; WINE doesn't implement the builtin classname atoms
+    ; https://bugs.winehq.org/show_bug.cgi?id=49195
+    ; Define it on stack instead.
+    push 0x00004349
+    push 0x54415453
+    mov ecx,esp
+%endif
+    ; ARGS OF  CreateWindowExA
+    push eax                  ; lpParam
+    push eax                  ; hInstance
+    push eax                  ; hMenu
+    push eax                  ; hWndParent
+    cdq
+    mov dl,160
+    lea ebx,[edx*3] ; 160*3
+    push ebx                  ; nHeight       = 480
+    add ebx,edx ; 480+160 = 0x280
+    push ebx                  ; nWidth        = 640
+    shl ebx,24 ; 0x80000000
+    push ebx                  ; Y             = CW_USEDEFAULT
+    push ebx                  ; X             = CW_USEDEFAULT
+    push 0x10CF0000           ; dwStyle       = WS_VISIBLE|WS_OVERLAPPEDWINDOW
+    lea edx,REFREL(AppName)
+    push edx                  ; lpWindowName
+%ifdef WINECOMPAT
+    push ecx                  ; lpClassName
+%else
+    push 0xC019
+%endif
+    push eax                  ; dwExStyle
+    ; END ARGS CreateWindowExA
+
+    CALLIMPORT CreateWindowExA
+
+    mov REFREL(hwnd),eax
+
+    ; ARGS OF  UpdateWindow
+    push eax                  ; hWnd
+    ; END ARGS UpdateWindow
+
+    ; ARGS OF  SetWindowLongA
+    lea edx,REFREL(wndproc)
+    push edx                  ; dwNewLong
+    push -4                   ; nIndex = GWL_WNDPROC
+    push eax                  ; hWnd
+    ; END ARGS SetWindowLongA
+
+    CALLIMPORT SetWindowLongA
+
+    CALLIMPORT UpdateWindow
+
+    sub esp,0x20 ; allocate 0x20 for MSG
+
+  msgloop:
+    mov edx,esp ; msg
+    xor eax,eax
+    push eax                  ; wMsgFilterMax
+    push eax                  ; wMsgFilterMin
+    push eax                  ; hWnd
+    push edx                  ; lpMsg
+    CALLIMPORT GetMessageA
+    test eax,eax ; return value 0 means WM_QUIT
+    jnz noquit
+  quit:
+    ; Let whatever is on the stack be the exit status.
+    CALLIMPORT ExitProcess
+  noquit:
+
+    ; TranslateMessage's effects aren't used in the simple app.
+    ; push esp                  ; lpMsg
+    ; CALLIMPORT TranslateMessage
+    push esp                  ; lpMsg
+    CALLIMPORT DispatchMessageA
+
+    jmp msgloop
+
+relrefstart: ; 256b from here onwards are [ebp+byte] addressable
+
+  wndproc:
+    mov eax,regrelref
+    pushad ; regrelref restored to eax upon popad
+    mov ebp,eax
+    mov eax,[esp+0x28]
+    cmp eax,0x000F ; WM_PAINT
+    ; Handles also WM_SIZE.
+    ; Everything below 0x000F is also reasonable time to paint.
+    ja nopaint
+    cmp al,0x02 ; 0x0002 = WM_DESTROY
+    je quit
+
+    mov ebx,REFREL(hwnd)
+    lea esi,REFREL(rect)
+
+    ; ARGS OF  GetDC
+    push ebx                  ; hWnd
+    ; END ARGS GetDC
+    CALLIMPORT GetDC
+
+    ; Push all args ahead before calling functions.
+    ; Saves from needing to save hdc from eax.
+
+    ; ARGS OF  ReleaseDC
+    push eax                  ; hDC
+    push ebx                  ; hWnd
+    ; END ARGS ReleaseDC
+
+    ; ARGS OF  DrawTextA
+    push 0x25                 ; format = DT_SINGLELINE|DT_CENTER|DT_VCENTER
+    push esi                  ; lprc = the RECT
+    push -1                   ; cchText
+    lea edx,REFREL(AppName)
+    push edx                  ; lpchText
+    push eax                  ; hdc
+    ; END ARGS DrawTextA
+
+    ; ARGS OF  FillRect
+    push 17                   ; hbr
+    push esi                  ; lprc = the RECT
+    push eax                  ; hDC
+    ; END ARGS DrawTextA
+
+    ; ARGS OF  GetClientRect
+    push esi                  ; lpRect
+    push ebx                  ; hWnd
+    ; END ARGS GetClientRect
+
+    ; ARGS OF  SetBkMode
+    push 1                    ; mode = TRANSPARENT
+    push eax                  ; hdc
+    ; END ARGS SetBkMode
+
+    CALLIMPORT SetBkMode
+
+    CALLIMPORT GetClientRect
+
+    CALLIMPORT FillRect
+
+    CALLIMPORT DrawTextA
+
+    CALLIMPORT ReleaseDC
+
+    ; Fall through to DefWindowProc which will validate the rect.
+  nopaint:
+    popad ; Restore context, relref in eax
+    ; Tail call
+    jmp REFREL_REG(eax,pfnDefWindowProcA)
+
+AppName: db "Dave's Tiny App",0
+
+  align 4,db 0
+
+; Import table rules
+;   Library name must occupy 8 bytes, zero-padded as needed.
+;   Each library name must be followed by at least one hash.
+;     (remember this when debugging)
+
+importtable:
+; kernel32
+  pfnLoadLibraryA:
+    dd 0x71761F00
+  pfnExitProcess:
+    dd 0x32955300
+
+db "user32",0,0
+  pfnCreateWindowExA:
+    dd 0xF9C6B200
+  pfnSetWindowLongA:
+    dd 0x0B616900
+  pfnUpdateWindow:
+    dd 0x03687B00
+  pfnGetMessageA:
+    dd 0x83311D00
+; pfnTranslateMessage:
+;   dd 0xEA661C00
+  pfnDispatchMessageA:
+    dd 0x2EFBB200
+  pfnDefWindowProcA:
+    dd 0xB9C56D00
+  pfnGetDC:
+    dd 0x59D3C300
+  pfnReleaseDC:
+    dd 0xF2749D00
+  pfnGetClientRect:
+    dd 0x63EE0600
+  pfnFillRect:
+    dd 0x04AAE600
+  pfnDrawTextA:
+    dd 0xA18D6B00
+
+db "gdi32",0,0,0
+  pfnSetBkMode:
+    dd 0xE1789D00
+
+importtable_end:
+
+SIZEOFIMAGE equ $-exefile
+
+section bss nobits vfollows=bin
+
+hwnd: resd 1
+rect: resd 4
+

--- a/Theron/compile.bat
+++ b/Theron/compile.bat
@@ -1,0 +1,5 @@
+yasm -fbin -o .headersize.exe nothing.asm
+yasm -fbin -o HelloWindows.exe HelloWindows.asm
+yasm -fbin -o HelloCompat.exe HelloWindows.asm -DWINECOMPAT
+dir .headersize.exe HelloWindows.exe
+pause

--- a/Theron/compile.sh
+++ b/Theron/compile.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+yasm -fbin -o .headersize.exe nothing.asm
+yasm -fbin -o HelloWindows.exe HelloWindows.asm
+yasm -fbin -o HelloCompat.exe HelloWindows.asm -DWINECOMPAT
+ls -l .headersize.exe HelloWindows.exe

--- a/Theron/hash.c
+++ b/Theron/hash.c
@@ -1,0 +1,31 @@
+/*----------------------
+  hash.c
+  Calculate import hashes for header_tiny.asm
+
+  Usage: ./hash LoadLibraryA name2 name3 ...
+
+  2023-01-25  Theron Tarigo
+
+----------------------*/
+
+#include <stdio.h>
+
+static unsigned int multiplier=5651;
+
+int main (int argc, char **argv) {
+  for (int i=1;i<argc;i++) {
+    const char *n;
+    n=argv[i];
+    unsigned int a=0;
+    unsigned char c;
+    do {
+      a*=multiplier;
+      c=*n++;
+      a&=0xFFFFFF00;a|=c;
+    } while(c);
+    printf("  pfn%s:\n",argv[i]);
+    printf("    dd 0x%08X\n",a);
+  }
+  return 0;
+}
+

--- a/Theron/header_extracted.asm
+++ b/Theron/header_extracted.asm
@@ -21,8 +21,6 @@ times %%A-%%B db 0
 times %%B-%%A db 0
 %endmacro
 
-SECTALIGN equ 0x4
-FILEALIGN equ 0x4
 IMGBASE equ 0x400000
 %define RVA(x) ((x)-IMGBASE)
 
@@ -200,7 +198,7 @@ execpartB:
     mov ebx,eax
     add edi,8
     nonextlib:
-    cmp di,importtable_end-0xFFFF
+    cmp di,importtable_end-IMGBASE
     jnz importloop
 
     ; END OF HASH LOADER

--- a/Theron/header_extracted.asm
+++ b/Theron/header_extracted.asm
@@ -1,0 +1,208 @@
+;-----------------------
+; header_extracted.asm
+; Version of header_tiny.asm with program code taken out of the header fields;
+; Hand-written PE32 format headers and hash-based function import;
+; Heavily borrowing techniques from Crinkler,
+;   https://github.com/runestubbe/Crinkler
+;
+; Given N imports and M libraries, the importer pushes O(N*M) items to stack
+; which are never cleaned up.  This is not anticipated to cause overflow.
+;
+; 2023-01-27  Theron Tarigo
+;
+;-----------------------
+
+bits 32
+
+%macro ASSERTEQ 2
+%%A equ %1
+%%B equ %2
+times %%A-%%B db 0
+times %%B-%%A db 0
+%endmacro
+
+SECTALIGN equ 0x4
+FILEALIGN equ 0x4
+IMGBASE equ 0x400000
+%define RVA(x) ((x)-IMGBASE)
+
+section bin progbits start=0 vstart=IMGBASE
+
+exefile:
+doshdr:
+  dw "MZ"
+  dw "TT"
+pehdr:
+  dw "PE",0                                 ; Signature = "PE",0,0
+  dw 0x014C                                 ; Machine = i386
+  dw 0                                      ; NumberOfSections = 0
+
+;execpart0:
+  dd 0x90909090                             ; TimeDateStamp
+  dd 0x90909090                             ; PointerToSymbolTable
+  dd 0x90909090                             ; NumberOfSymbols
+
+ASSERTEQ $-pehdr,0x14
+  dw 0x0140                                 ; SizeOfOptionalHeader
+  dw 0xD8DE                                 ; Characteristics
+
+ASSERTEQ $-exefile,0x1C
+opthdr:
+  dw 0x010B                                 ; Magic = PE32
+  db 0xDA                                   ; MajorLinkerVersion
+
+;execpart1:
+  db 0x90                                   ; MinorLinkerVersion
+  dd 0x90909090                             ; SizeOfCode
+  dd 0x90909090                             ; SizeOfInitializedData
+  dd 0x90909090                             ; SizeOfUninitializedData
+
+ASSERTEQ $-opthdr,0x10
+  dd RVA(unpacked_entry)                    ; AddressOfEntryPoint
+
+;execpart2:
+  dd 0x90909090                             ; BaseOfCode
+  dd 0x90909090                             ; BaseOfData
+
+ASSERTEQ $-opthdr,0x1C
+  dd IMGBASE                                ; ImageBase
+ASSERTEQ $-exefile,0x3C                     ; (overlapped fields)
+ASSERTEQ 0x4,pehdr-exefile                  ; { PE hdr offset
+  dd 0x4                                    ;   SectionAlignment }
+  dd 0x4                                    ; FileAlignment
+
+;execpart3:
+  dd 0x9090                                 ; MajorOperatingSystemVersion
+  dd 0x9090                                 ; MinorOperatingSystemVersion
+
+ASSERTEQ $-opthdr,0x30
+  dw 0x4                                    ; MajorSubsystemVersion
+
+;execpart4:
+  dw 0x9090                                 ; MinorSubsystemVersion
+  dd 0x90909090                             ; Win32VersionValue
+  dd 0x25C93118                             ; SizeOfImage
+
+ASSERTEQ $-opthdr,0x3C
+  dd 0x0000002C                             ; SizeOfHeaders
+
+;execpart5:
+  dd 0x90909090                             ; Checksum
+
+ASSERTEQ $-opthdr,0x44
+  dw 0x0002                                 ; Subsystem = gui
+  dw 0x8906                                 ; DllCharacteristics
+  dd 0x134403D8                             ; SizeOfStackReserve
+  dd 0x03DA8978                             ; SizeOfStackCommit
+  dd 0x0F532450                             ; SizeOfHeapReserve
+  dd 0x034A14B7                             ; SizeOfHeapCommit
+  dd 0x90909090                             ; LoaderFlags
+
+ASSERTEQ $-opthdr,0x5C
+  dd 0                                      ; NumberOfRvaAndSizes
+
+regrelref equ relrefstart+0x80
+%define REFREL_REG(R,N) dword[byte R+((N)-regrelref)]
+%define REFREL(N) REFREL_REG(ebp,N)
+%macro CALLIMPORT 1
+  call REFREL(pfn %+ %1)
+%endmacro
+
+unpacked_entry:
+
+execpart2:
+    mov eax,[ebx+0xC]         ; 8B430C  [0:1] BaseOfCode
+    mov eax,[eax+0xC]         ; 8B400C  [2:3]  ...
+    jmp short execpart3       ; EBxx          BaseOfData
+
+execpart3:
+    mov ebp,regrelref       ; BDxxxx4000  [0:1/0:1/0] {Major/Minor}
+    IMPTBLOFFSET equ importtable-regrelref          ; OperatingSystemVersion //
+    lea edi,[ebp+IMPTBLOFFSET]  ; 8D7Dxx  [1/0:1]   {Major/Minor}ImageVersion
+
+;opthdr+0x30:
+    add al,0x0                ; 0400
+
+execpart4:
+    mov eax,[eax]             ; 8B00          MinorSubsystemVersion
+    mov eax,[eax]             ; 8B00    [0:1] Win32VersionValue
+    mov ebx,[eax+0x18]        ; 8B5818  [2:3/0] /// SizeOfImage
+  importloop:
+    xor ecx,ecx               ; 31C9    [1:2]  ...(SizeOfImage)
+  searchloop:
+
+;opthdr+0x3B:
+    and eax,0x2C              ; 252C000000
+
+execpart5:
+    mov edx,[ebx+0x3C]        ; 8B533C  [0:2] Checksum
+
+;opthdr+0x43
+    add al,[fs:eax]           ; 640200  [3/0:1] Subsystem = gui
+    push es                   ; 06      [0  ] DllCharacteristics
+    mov eax,ebx               ; 89D8    [1/0]  /// SizeOfStackReserve
+
+; EE: any value allowed
+; ll: keep under 0x20
+
+;  StacRes StacCom HeapRes HeapCom LdrFlag nRVA&sz
+; EEEEEEllEEEEEEllEEEEEEllEEEEEEllEEEEJJJJ00000000
+; D8
+;   03441378
+;           89DA
+;               035024
+;                     53
+;                       0FB7144A
+;                               03581C
+;                                     EBxx
+
+    add eax,[ebx+edx+0x78]    ; 03441378
+    mov edx,ebx               ; 89DA  (add)
+    add edx,[eax+0x24]        ; 035024
+
+    push ebx                  ; 53
+    movzx edx,word[edx+2*ecx] ; 0FB7144A
+    add ebx,[eax+0x1C]        ; 03581C
+
+    jmp short execpart0
+
+execpart0:
+    mov edx,[ebx+4*edx]       ; 8B1496  [0:2] TimeDateStamp
+    pop ebx                   ; 5B      [  3] TimeDateStamp
+    mov eax,[eax+0x20]        ; 8B4020  [0:2] PointerToSymbolTable
+    add eax,ebx               ; 01D8    [3/0]     ///
+    mov esi,[eax+4*ecx]       ; 033488  [1:3] NumberOfSymbols
+;pehdr+0x14:
+    inc eax                   ; 40      [0  ] SizeOfOptionalHeader
+    add esi,ebx               ; 01DE    [1/0] Characteristics ///
+    fmul dword[ebx]           ; D80B    [1/0] Magic ///
+    add edx,ebx               ; 01DA    [1/0] MajorLinkerVersion
+
+execpart1:
+    xor eax,eax               ; 31C0    [0/0] MinorLinkerVersion ///
+  hashloop:
+    imul eax,5651       ; 69C013160000  [1:3/0:2] SizeOfCode ///
+    lodsb                     ; AC      [  3] SizeOfInitializedData
+    test al,al                ; 84C0    [0:1] SizeOfUninitializedData
+    jmp short execpartB       ; EBxx    [2:3]  ...
+
+execpartB:
+    jnz hashloop
+    inc ecx
+    cmp eax,[edi]
+    jne searchloop
+    mov [edi],edx
+    add edi,4
+    push edi
+    CALLIMPORT LoadLibraryA
+    test eax,eax
+    jz nonextlib
+    mov ebx,eax
+    add edi,8
+    nonextlib:
+    cmp di,importtable_end&0xFFFF
+    jnz importloop
+
+    ; END OF HASH LOADER
+    ; eax = 0
+

--- a/Theron/header_extracted.asm
+++ b/Theron/header_extracted.asm
@@ -200,7 +200,7 @@ execpartB:
     mov ebx,eax
     add edi,8
     nonextlib:
-    cmp di,importtable_end&0xFFFF
+    cmp di,importtable_end-0xFFFF
     jnz importloop
 
     ; END OF HASH LOADER

--- a/Theron/header_tiny.asm
+++ b/Theron/header_tiny.asm
@@ -134,7 +134,7 @@ execpartB:
     mov ebx,eax
     add edi,8
     nonextlib:
-    cmp di,importtable_end&0xFFFF
+    cmp di,importtable_end-IMGBASE
     jnz importloop
 
     ; END OF HASH LOADER

--- a/Theron/header_tiny.asm
+++ b/Theron/header_tiny.asm
@@ -1,0 +1,142 @@
+;-----------------------
+; header_unpacked.asm
+; Version of header_tiny.asm without using program code in the header fields;
+; Hand-written PE32 format headers and hash-based function import;
+; Heavily borrowing techniques from Crinkler,
+;   https://github.com/runestubbe/Crinkler
+;
+; Given N imports and M libraries, the importer pushes O(N*M) items to stack
+; which are never cleaned up.  This is not anticipated to cause overflow.
+;
+; 2023-01-27  Theron Tarigo   160 bytes header+importer+LoadLibraryA hash
+;
+;-----------------------
+
+bits 32
+
+%macro ASSERTEQ 2
+%%A equ %1
+%%B equ %2
+times %%A-%%B db 0
+times %%B-%%A db 0
+%endmacro
+
+IMGBASE equ 0x400000
+%define RVA(x) ((x)-IMGBASE)
+
+section bin progbits start=0 vstart=IMGBASE
+
+; Overlapped data/executable notation:
+;   Values ignored by PE loader:  written instructions, bytes in comments
+; Values significant to loader:   written bytes, disassembly in comments
+
+exefile:
+doshdr:
+  dw "MZ"
+  dw "TT"
+pehdr:
+  dw "PE",0                                 ; Signature = "PE",0,0
+  dw 0x014C                                 ; Machine = i386
+  dw 0                                      ; NumberOfSections = 0
+
+execpart0:
+    mov edx,[ebx+4*edx]       ; 8B1496  [0:2] TimeDateStamp
+    pop ebx                   ; 5B      [  3] TimeDateStamp
+    mov eax,[eax+0x20]        ; 8B4020  [0:2] PointerToSymbolTable
+    add eax,ebx               ; 01D8    [3/0]     ///
+    mov esi,[eax+4*ecx]       ; 033488  [1:3] NumberOfSymbols
+
+ASSERTEQ $-pehdr,0x14
+  dw 0x0140   ; inc eax / add...              SizeOfOptionalHeader
+  dw 0xD8DE   ; esi,ebx / fmul...             Characteristics
+
+ASSERTEQ $-exefile,0x1C
+opthdr:
+  dw 0x010B   ; dword[ebx] / add...           Magic = PE32
+  db 0xDA     ; edx,ebx                       MajorLinkerVersion
+execpart1:
+    xor eax,eax               ; 31C0    [0/0] MinorLinkerVersion ///
+  hashloop:
+    imul eax,5651       ; 69C013160000  [1:3/0:2] SizeOfCode ///
+    lodsb                     ; AC      [  3] SizeOfInitializedData
+    test al,al                ; 84C0    [0:1] SizeOfUninitializedData
+    jmp short execpartB       ; EBxx    [2:3]  ...
+
+ASSERTEQ $-opthdr,0x10
+  dd RVA(execpart2)                         ; AddressOfEntryPoint
+
+execpart2:
+    mov eax,[ebx+0xC]         ; 8B430C  [0:1] BaseOfCode
+    mov eax,[eax+0xC]         ; 8B400C  [2:3]  ...
+    jmp short execpart3       ; EBxx          BaseOfData
+
+ASSERTEQ $-opthdr,0x1C
+  dd IMGBASE                                ; ImageBase
+ASSERTEQ $-exefile,0x3C                     ; (overlapped fields)
+ASSERTEQ 0x4,pehdr-exefile                  ; { PE hdr offset
+  dd 0x4                                    ;   SectionAlignment }
+  dd 0x4                                    ; FileAlignment
+
+execpart3:
+    mov ebp,regrelref       ; BDxxxx4000  [0:1/0:1/0] {Major/Minor}
+    IMPTBLOFFSET equ importtable-regrelref          ; OperatingSystemVersion //
+    lea edi,[ebp+IMPTBLOFFSET]  ; 8D7Dxx  [1/0:1]   {Major/Minor}ImageVersion
+
+ASSERTEQ $-opthdr,0x30
+  dw 0x4      ; add al,0x0                    MajorSubsystemVersion
+
+execpart4:
+    mov eax,[eax]             ; 8B00          MinorSubsystemVersion
+    mov eax,[eax]             ; 8B00    [0:1] Win32VersionValue
+    mov ebx,[eax+0x18]        ; 8B5818  [2:3/0] /// SizeOfImage
+  importloop:
+    xor ecx,ecx               ; 31C9    [1:2]  ...(SizeOfImage)
+  searchloop:
+
+  db 0x25       ; and eax,              [  3]  ...(SizeOfImage)
+ASSERTEQ $-opthdr,0x3C
+  dd 0x0000002C ;         0x2C                SizeOfHeaders
+
+execpart5:
+    mov edx,[ebx+0x3C]        ; 8B533C  [0:2] Checksum
+  db 0x64    ; fs:                      [  3]  ...
+
+ASSERTEQ $-opthdr,0x44
+  dw 0x0002  ; add al,[:::eax]                Subsystem = gui
+  dw 0x8906  ; push es / mov..                DllCharacteristics
+  dd 0x134403D8 ;.. eax,ebx / add eax,[ebx+edx+...        SizeOfStackReserve
+  dd 0x03DA8978 ;.. 0x78] / mov edx,ebx / add...          SizeOfStackCommit
+  dd 0x0F532450 ;.. edx,[eax+0x24] / push ebx / movzx...  SizeOfHeapReserve
+  dd 0x034A14B7 ;.. edx,word[edx+2*ecx] / add..           SizeOfHeapCommit
+  dw 0x1C58     ;.. ebx,[eax+0x1C]                  [0:1] LoaderFlags
+    jmp short execpart0       ; EBxx                [2:3]  ..
+ASSERTEQ $-opthdr,0x5C
+  dd 0                                      ; NumberOfRvaAndSizes
+
+regrelref equ relrefstart+0x80
+%define REFREL_REG(R,N) dword[byte R+((N)-regrelref)]
+%define REFREL(N) REFREL_REG(ebp,N)
+%macro CALLIMPORT 1
+  call REFREL(pfn %+ %1)
+%endmacro
+
+execpartB:
+    jnz hashloop
+    inc ecx
+    cmp eax,[edi]
+    jne searchloop
+    mov [edi],edx
+    add edi,4
+    push edi
+    CALLIMPORT LoadLibraryA
+    test eax,eax
+    jz nonextlib
+    mov ebx,eax
+    add edi,8
+    nonextlib:
+    cmp di,importtable_end&0xFFFF
+    jnz importloop
+
+    ; END OF HASH LOADER
+    ; eax = 0
+

--- a/Theron/header_unpacked.asm
+++ b/Theron/header_unpacked.asm
@@ -21,8 +21,6 @@ times %%A-%%B db 0
 times %%B-%%A db 0
 %endmacro
 
-SECTALIGN equ 0x4
-FILEALIGN equ 0x4
 IMGBASE equ 0x400000
 %define RVA(x) ((x)-IMGBASE)
 
@@ -171,7 +169,7 @@ unpacked_entry:
     mov ebx,eax               ; found -> start importing from this module
     add edi,8                 ; go to first hash
     nonextlib:
-    cmp di,importtable_end-0xFFFF ; RVA(importtable_end)<0xFFFF, saves 1 byte
+    cmp di,importtable_end-IMGBASE; RVA(importtable_end)<0xFFFF, saves 1 byte
     jnz importloop            ; more hashes to import
 
     ; END OF HASH LOADER

--- a/Theron/header_unpacked.asm
+++ b/Theron/header_unpacked.asm
@@ -1,0 +1,179 @@
+;-----------------------
+; header_unpacked.asm
+; Hand-written PE32 format headers and hash-based function import;
+; All notes on header packing removed to better illustrate importer;
+; Heavily borrowing techniques from Crinkler,
+;   https://github.com/runestubbe/Crinkler
+;
+; Given N imports and M libraries, the importer pushes O(N*M) items to stack
+; which are never cleaned up.  This is not anticipated to cause overflow.
+;
+; 2023-01-27  Theron Tarigo
+;
+;-----------------------
+
+bits 32
+
+%macro ASSERTEQ 2
+%%A equ %1
+%%B equ %2
+times %%A-%%B db 0
+times %%B-%%A db 0
+%endmacro
+
+SECTALIGN equ 0x4
+FILEALIGN equ 0x4
+IMGBASE equ 0x400000
+%define RVA(x) ((x)-IMGBASE)
+
+section bin progbits start=0 vstart=IMGBASE
+
+exefile:
+doshdr:
+  dw "MZ"
+  dw "TT"
+pehdr:
+  dw "PE",0                                 ; Signature = "PE",0,0
+  dw 0x014C                                 ; Machine = i386
+  dw 0                                      ; NumberOfSections = 0
+
+;execpart0:
+  dd 0x90909090                             ; TimeDateStamp
+  dd 0x90909090                             ; PointerToSymbolTable
+  dd 0x90909090                             ; NumberOfSymbols
+
+ASSERTEQ $-pehdr,0x14
+  dw 0x0140                                 ; SizeOfOptionalHeader
+  dw 0xD8DE                                 ; Characteristics
+
+ASSERTEQ $-exefile,0x1C
+opthdr:
+  dw 0x010B                                 ; Magic = PE32
+  db 0xDA                                   ; MajorLinkerVersion
+
+;execpart1:
+  db 0x90                                   ; MinorLinkerVersion
+  dd 0x90909090                             ; SizeOfCode
+  dd 0x90909090                             ; SizeOfInitializedData
+  dd 0x90909090                             ; SizeOfUninitializedData
+
+ASSERTEQ $-opthdr,0x10
+  dd RVA(unpacked_entry)                    ; AddressOfEntryPoint
+
+;execpart2:
+  dd 0x90909090                             ; BaseOfCode
+  dd 0x90909090                             ; BaseOfData
+
+ASSERTEQ $-opthdr,0x1C
+  dd IMGBASE                                ; ImageBase
+ASSERTEQ $-exefile,0x3C                     ; (overlapped fields)
+ASSERTEQ 0x4,pehdr-exefile                  ; { PE hdr offset
+  dd 0x4                                    ;   SectionAlignment }
+  dd 0x4                                    ; FileAlignment
+
+;execpart3:
+  dd 0x9090                                 ; MajorOperatingSystemVersion
+  dd 0x9090                                 ; MinorOperatingSystemVersion
+
+ASSERTEQ $-opthdr,0x30
+  dw 0x4                                    ; MajorSubsystemVersion
+
+;execpart4:
+  dw 0x9090                                 ; MinorSubsystemVersion
+  dd 0x90909090                             ; Win32VersionValue
+  dd 0x25C93118                             ; SizeOfImage
+
+ASSERTEQ $-opthdr,0x3C
+  dd 0x0000002C                             ; SizeOfHeaders
+
+;execpart5:
+  dd 0x90909090                             ; Checksum
+
+ASSERTEQ $-opthdr,0x44
+  dw 0x0002                                 ; Subsystem = gui
+  dw 0x8906                                 ; DllCharacteristics
+  dd 0x134403D8                             ; SizeOfStackReserve
+  dd 0x03DA8978                             ; SizeOfStackCommit
+  dd 0x0F532450                             ; SizeOfHeapReserve
+  dd 0x034A14B7                             ; SizeOfHeapCommit
+  dd 0x90909090                             ; LoaderFlags
+
+ASSERTEQ $-opthdr,0x5C
+  dd 0                                      ; NumberOfRvaAndSizes
+
+regrelref equ relrefstart+0x80
+%define REFREL_REG(R,N) dword[byte R+((N)-regrelref)]
+%define REFREL(N) REFREL_REG(ebp,N)
+%macro CALLIMPORT 1
+  call REFREL(pfn %+ %1)
+%endmacro
+
+unpacked_entry:
+    ; upon entry, ebx points to the PEB
+    mov eax,[ebx+0xC]  ; PEB->Ldr
+    mov eax,[eax+0xC]  ; Ldr->InMemoryOrderModuleList
+
+    mov ebp,regrelref   ; Set up base pointer for REFREL
+    IMPTBLOFFSET equ importtable-regrelref
+    lea edi,[ebp+IMPTBLOFFSET]; Ready for the first import hash
+
+    add al,0x0                ; header constrained
+
+    mov eax,[eax]             ; Flink to 1st module, NtDll
+    mov eax,[eax]             ; Flink to 2nd module, Kernel32
+    mov ebx,[eax+0x18]        ; Entry->DllBase (Kernel32 in ebx)
+  importloop:                 ; iterate over imports
+    xor ecx,ecx               ; start, namenumber = 0
+  searchloop:                 ; iterate over names
+
+    and eax,0x2C              ; header constrained, useful for next constraint
+
+    mov edx,[ebx+0x3C]        ; PE signature offset
+
+    add al,[fs:eax]           ; header constrained, eax<=0x2C
+    push es                   ; header constrained
+    mov eax,ebx               ; (module address base)
+
+    add eax,[ebx+edx+0x78]    ; Export Table
+    mov edx,ebx               ; (module address base)
+    add edx,[eax+0x24]        ; AddressOfNameOrdinals
+
+    push ebx                  ; (module address base)
+    movzx edx,word[edx+2*ecx] ; NameOrdinals[namenumber](offset)
+    add ebx,[eax+0x1C]        ; AddressOfFunctions(address)
+
+    mov edx,[ebx+4*edx]       ; Functions[ordinal](offset)
+    pop ebx                   ; (restore)
+    mov eax,[eax+0x20]        ; AddressOfNames(offset)
+    add eax,ebx               ; AddressOfNames(address)
+    mov esi,[eax+4*ecx]       ; Names[namenumber](offset)
+    inc eax                   ; header constrained
+    add esi,ebx               ; Names[namenumber](address)
+    fmul dword[ebx]           ; header constrained
+    add edx,ebx               ; Functions[ordinal](address)
+
+    xor eax,eax               ; begin hashing
+  hashloop:
+    imul eax,5651
+    lodsb
+    test al,al
+    jnz hashloop              ; done on null termination
+
+    inc ecx                   ; next exported name
+    cmp eax,[edi]             ; compare to hash in importtable
+    jne searchloop            ; try again
+    mov [edi],edx             ; replace hash with resolved address
+    add edi,4                 ; next import
+    push edi                  ; try the next table entry as a library name
+    CALLIMPORT LoadLibraryA
+    test eax,eax
+    jz nonextlib              ; not found => it wasn't a library name at all
+    mov ebx,eax               ; found -> start importing from this module
+    add edi,8                 ; go to first hash
+    nonextlib:
+    cmp di,importtable_end&0xFFFF ; RVA(importtable_end)<0xFFFF, saves 1 byte
+    jnz importloop            ; more hashes to import
+
+    ; END OF HASH LOADER
+    ; eax = 0
+

--- a/Theron/header_unpacked.asm
+++ b/Theron/header_unpacked.asm
@@ -171,7 +171,7 @@ unpacked_entry:
     mov ebx,eax               ; found -> start importing from this module
     add edi,8                 ; go to first hash
     nonextlib:
-    cmp di,importtable_end&0xFFFF ; RVA(importtable_end)<0xFFFF, saves 1 byte
+    cmp di,importtable_end-0xFFFF ; RVA(importtable_end)<0xFFFF, saves 1 byte
     jnz importloop            ; more hashes to import
 
     ; END OF HASH LOADER

--- a/Theron/nothing.asm
+++ b/Theron/nothing.asm
@@ -1,0 +1,13 @@
+;-----------------------
+; nothing.asm
+; Useful for checking minimum size of header+importer
+; Note that a valid Windows exe must be at least 268 bytes.
+;-----------------------
+
+%include "header_tiny.asm"
+relrefstart:
+importtable:
+  pfnLoadLibraryA:
+    dd 0x71761F00
+importtable_end:
+SIZEOFIMAGE equ $-exefile

--- a/templates/readme/README.md.template
+++ b/templates/readme/README.md.template
@@ -12,8 +12,9 @@ And the follow-up episode ["C vs ASM: Making the World's SMALLEST Windows App"](
 
 Code in the repository:
 
-- Current code is in the folder "Lasse"
-- Original code in the folder "TinyOriginal"
+- Optimized version of the original code in the folder "TinyOriginal"
+- Version applying shell coding tactics is in the folder "Lasse"
+- Version using a manually written PE header is in the folder "Theron"
 - QRCode is dead code, was the exe embedded into a QRCode, kept just for posterity
 
 The goal of this project is to make the smallest possible application, without compression, that has the following features:
@@ -42,7 +43,7 @@ If your virus scanner intervenes when you try to run the executables that come o
 
 ### Plain MASM32
 
-The current code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
+The code in the Lasse directory can be built with plain MASM32 11.0, which can be obtained from a number of sources. Build instructions using it are:
 
 ```shell
 ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
@@ -56,9 +57,9 @@ Crinkler is a compressing linker for Windows, specifically targeted towards exec
 
 Crinkler requires the Windows SDK to be installed. Best (i.e. smallest) results have been achieved with version 10.0.20348.0 of the Windows 10 SDK. It, and other versions can be downloaded from the [Windows SDK archive page](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) on the Microsoft website.
 
-After installing it, the build instructions for both applications are:
+After installing it, the build instructions for the applications that can be built using it are:
 
-- Current code in the Lasse directory:
+- Code in the Lasse directory:
 
   ```shell
   ml /c /coff LittleWindows.asm
@@ -67,7 +68,7 @@ After installing it, the build instructions for both applications are:
 
   The executable will be named out.exe.
 
-- Original code in the TinyOriginal directory:
+- Code in the TinyOriginal directory:
 
   ```shell
   ml /c /coff /IC:\masm32\include Tiny.asm 
@@ -75,6 +76,16 @@ After installing it, the build instructions for both applications are:
   ```
 
   The executable will be named tiny.exe.
+
+### Yasm
+
+The code in the Theron directory has to be built with Yasm, which is a rewrite of the NASM assembler under the "new" BSD license. It can be acquired from the [Yasm project download page](https://yasm.tortall.net/Download.html); choose the version "for general use". The assembler is assumed to be renamed to `yasm.exe`. Build instructions using it are:
+
+```shell
+yasm -fbin -o HelloWindows.exe HelloWindows.asm
+```
+
+The executable will be named HelloWindows.exe.
 
 ## Current sizes
 
@@ -84,4 +95,5 @@ Current smallest known working executable sizes as of <!--size-date--> are as fo
 |-|-|-:|
 | `Lasse\LittleWindows.asm` | MASM32 | <!--size-little-masm--> |
 | `Lasse\LittleWindows.asm` | Crinkler | <!--size-little-crinkler--> |
+| `Theron\HelloWindows.asm` | Yasm | <!--size-hello-yasm--> |
 | `TinyOriginal\Tiny.asm` | Crinkler | <!--size-tiny-crinkler--> |

--- a/tools/build-all.ps1
+++ b/tools/build-all.ps1
@@ -1,14 +1,18 @@
 # This script builds both plain MASM32 and Crinkler versions of both the Lasse and TinyOriginal programs
-# The script assumes that MASM32 and the Windows SDK are installed in their default directories
+# The script assumes that MASM32 and the Windows SDK are installed in their default directories. Yasm is assumed to be installed in c:\yasm and to be called yasm.exe.
 # Run this script from the repository root, as in: .\tools\build-all.ps1
 
 # Build Lasse executables
 Set-Location .\Lasse
-c:\masm32\bin\ml /coff LittleWindows.asm /link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
 c:\masm32\bin\ml /c /coff LittleWindows.asm
+c:\masm32\bin\link /merge:.rdata=.text /merge:.data=.text /align:4 /subsystem:windows LittleWindows.obj
 ..\Crinkler\crinkler.exe /NODEFAULTLIB /ENTRY:start /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:1000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib LittleWindows.obj
 
-# Build TinyOriginal executables
+# Build Theron executable
+Set-Location ..\Theron
+c:\yasm\yasm.exe -fbin -o HelloWindows.exe HelloWindows.asm
+
+# Build TinyOriginal executable
 Set-Location ..\TinyOriginal
 c:\masm32\bin\ml /c /coff /IC:\masm32\include Tiny.asm
 ..\Crinkler\crinkler.exe /ENTRY:MainEntry /SUBSYSTEM:WINDOWS /TINYHEADER /NOINITIALIZERS /UNSAFEIMPORT /ORDERTRIES:2000 /TINYIMPORT /LIBPATH:"C:\Program Files (x86)\Windows Kits\10\Lib\10.0.20348.0\um\x86" kernel32.lib user32.lib gdi32.lib Tiny.obj /OUT:tiny.exe

--- a/tools/build-check.ps1
+++ b/tools/build-check.ps1
@@ -29,7 +29,7 @@ Function RunExecutable {
 }
 
 # Clean up any obj and exe files
-Remove-Item .\Lasse\*.obj,.\Lasse\*.exe,.\TinyOriginal\*.obj,.\TinyOriginal\*.exe -ErrorAction Ignore
+Remove-Item .\Lasse\*.obj,.\Lasse\*.exe,.\Theron\*.exe,.\TinyOriginal\*.obj,.\TinyOriginal\*.exe -ErrorAction Ignore
 
 # Build all executables
 .\tools\build-all.ps1
@@ -37,6 +37,7 @@ Remove-Item .\Lasse\*.obj,.\Lasse\*.exe,.\TinyOriginal\*.obj,.\TinyOriginal\*.ex
 # Test and check each executable
 $success = RunExecutable ".\Lasse\LittleWindows.exe" 
 $success = (RunExecutable ".\Lasse\out.exe") -and $success
+$success = (RunExecutable ".\Theron\HelloWindows.exe") -and $success
 $success = (RunExecutable ".\TinyOriginal\tiny.exe") -and $success
 
 Write-Host ""

--- a/tools/update-readme-sizes.ps1
+++ b/tools/update-readme-sizes.ps1
@@ -11,7 +11,10 @@ $fileContent = $fileContent -replace '<!--size-date-->', (Get-Date).ToString('MM
 $fileContent = $fileContent -replace '<!--size-little-masm-->', (Get-Item .\Lasse\LittleWindows.exe).Length
 $fileContent = $fileContent -replace '<!--size-little-crinkler-->', (Get-Item .\Lasse\out.exe).Length
 
-# Insert file sizes for TinyOriginal executables 
+# Insert file sizes for Theron executable 
+$fileContent = $fileContent -replace '<!--size-hello-yasm-->', (Get-Item .\Theron\HelloWindows.exe).Length
+
+# Insert file sizes for TinyOriginal executable 
 $fileContent = $fileContent -replace '<!--size-tiny-crinkler-->', (Get-Item .\TinyOriginal\tiny.exe).Length
 
 Set-Content -Value $fileContent -Path '.\README.md'


### PR DESCRIPTION
The PE32 format headers are written for maximal packing of executable instructions into the data fields.  This is also how Crinkler works, except that Crinkler uses these bytes for decompressor code, whereas for such a small app, the compression overhead is not advantageous and this space should be used for the hash-based function import instead.
Technically unneeded Win32 calls are removed: what was once done with RegisterClassEx can be done instead with STATIC class, FillRect, SetWindowLongA, and DefWindowProcA.

Note I haven't committed an update to README.md with the sizes - that should come after someone confirms this version working on another computer.  If this version does not work _on a system where Crinkler-linked executables do work_, please give details so this PR can be withdrawn and fixed.