### PR TITLE
Fix call to API with wrong character set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The executable will be named HelloWindows.exe.
 
 ## Current sizes
 
-Current smallest known working executable sizes as of 02/02/2023 are as follows:
+Current smallest known working executable sizes as of 02/06/2023 are as follows:
 
 | Program | Linker | Size in bytes |
 |-|-|-:|

--- a/TinyOriginal/Tiny.asm
+++ b/TinyOriginal/Tiny.asm
@@ -33,7 +33,7 @@ EXTERN _imp__RegisterClassExA@4 :PTR ;;
 EXTERN _imp__UpdateWindow@4 :PTR ;;
 EXTERN _imp__GetMessageA@16 :PTR ;;
 EXTERN _imp__TranslateMessage@4 :PTR ;;
-EXTERN _imp__DispatchMessageW@4 :PTR ;;
+EXTERN _imp__DispatchMessageA@4 :PTR ;;
 EXTERN _imp__PostQuitMessage@4 :PTR ;;
 EXTERN _imp__SetBkMode@8 :PTR ;;
 EXTERN _imp__GetClientRect@8 :PTR ;;
@@ -127,7 +127,7 @@ MessageLoop:
 
 	lea	eax, msg				; Dispatch 'msg'
 	push	eax
-	call	[ _imp__DispatchMessageW@4 ]
+	call	[ _imp__DispatchMessageA@4 ]
 
 	jmp	MessageLoop
 


### PR DESCRIPTION
DispatchMessageW was being called even though the rest of the program is/was using ANSI APIs. Fix pointer and call.

Signed-off-by: Charles Stevens <chazste@yahoo.com>