### PR TITLE
Remove call to GetStatupInfoA

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ The executable will be named HelloWindows.exe.
 
 ## Current sizes
 
-Current smallest known working executable sizes as of 02/06/2023 are as follows:
+Current smallest known working executable sizes as of 03/05/2023 are as follows:
 
 | Program | Linker | Size in bytes |
 |-|-|-:|
 | `Lasse\LittleWindows.asm` | MASM32 | 1104 |
 | `Lasse\LittleWindows.asm` | Crinkler | 818 |
 | `Theron\HelloWindows.asm` | Yasm | 383 |
-| `TinyOriginal\Tiny.asm` | Crinkler | 572 |
+| `TinyOriginal\Tiny.asm` | Crinkler | 542 |

--- a/TinyOriginal/Tiny.asm
+++ b/TinyOriginal/Tiny.asm
@@ -28,7 +28,6 @@ WindowHeight	equ 480
 EXTERN _imp__BeginPaint@8 :PTR ;;
 EXTERN _imp__CreateWindowExA@48 :PTR ;;
 EXTERN _imp__GetModuleHandleA@4 :PTR ;;
-EXTERN _imp__GetStartupInfoA@4 :PTR ;;
 EXTERN _imp__RegisterClassExA@4 :PTR ;;
 EXTERN _imp__UpdateWindow@4 :PTR ;;
 EXTERN _imp__GetMessageA@16 :PTR ;;
@@ -51,7 +50,6 @@ AppName		db "Dave's Tiny App", 0		        ; The name of our main window
 MainEntry proc NEAR
 
 	LOCAL   hInstance:HINSTANCE                     ; Was global in .DATA? before, now a local
-	LOCAL	sui:STARTUPINFOA		        ; Reserve stack space so we can load and inspect the STARTUPINFO
 	LOCAL	wc:WNDCLASSEX			        ; Create these vars on the stack, hence LOCAL
 	LOCAL	msg:MSG
 	LOCAL	hwnd:HWND
@@ -59,18 +57,6 @@ MainEntry proc NEAR
 	push	NULL			        	; Get the instance handle of our app (NULL means ourselves)
 	call 	[ _imp__GetModuleHandleA@4 ] ; GetModuleHandle will return instance handle in EAX
 	mov	hInstance, eax		        	; Cache it in our global variable
-
-
-	; Get the startup mode for the window from the STARTUPINFO
-
-	lea	eax, sui			        ; Get the STARTUPINFO for this process
-	push	eax
-	call	[ _imp__GetStartupInfoA@4 ]	; Find out if wShowWindow should be used
-	test	byte ptr sui.dwFlags, STARTF_USESHOWWINDOW
-	jnz	@1
-	mov	byte ptr sui.wShowWindow, SW_SHOWDEFAULT ; Use the default 
-@1:
-	push	sui.wShowWindow		      		; If the show window flag bit was nonzero, we use wShowWindow
 
 	mov	wc.cbSize, SIZEOF WNDCLASSEX		; Fill in the values in the members of our windowclass
 	mov	wc.style, CS_HREDRAW or CS_VREDRAW	; Redraw if resized in either dimension


### PR DESCRIPTION
Special handling of last argument to ShowWindow (Called by CreateWindowEx) is not necessary. Therefore drop call and save about 80 bytes in the normal link and about 33 bytes using crinkler.

Tested using a shortcut and setting the run option to start with the window either maximized or minimized.

Also tested using the test program provided by @davepl in the discussion #26 

@rbergen I am seeing 539 bytes when using Crinkler.  That is a larger savings than I was expecting. 

Signed-off-by: Charles Stevens <chazste@yahoo.com>